### PR TITLE
fix re-creating editor, edit popover text

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <button id="rename-btn">Переименовать</button>
     </div>
     <div class="containerMain">
-      <p id="popover">Popover Text</p>
+      <p id="popover"></p>
       <div class="leftBar">
         <ul id="root" class="file-tree file-list"></ul>
       </div>

--- a/src/init.ts
+++ b/src/init.ts
@@ -127,7 +127,6 @@ export default (): void => {
             elements.openContentTab.textContent = '';
           }
           elements.openContentTab?.appendChild(editor);
-          Preview(item.content);
         });
   
         closeBtn.addEventListener('click', () => {


### PR DESCRIPTION
1. Fixed the problem of duplicating the editor element when switching tabs
2. Initial text of the popover was removed